### PR TITLE
Update error-prone to 2.4.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ subprojects {
         // All dependency versions.
         autoValueVersion = '1.7'
         classGraphVersion = '4.8.65'
-        errorproneVersion = '2.3.4'
+        errorproneVersion = '2.4.0'
         floggerVersion = '0.5.1'
         googleCloudStorageVersion = '1.103.1'
         guavaVersion = '28.2-jre'


### PR DESCRIPTION
This updates `error-prone` to 2.4.0 because I was encountering build failure on 2.3.4 when running `./gradlew shadowJar` manually and via `quick_start.sh` - details @ [build_failure.txt](https://github.com/google/tsunami-security-scanner/files/4893575/build_failure.txt).

After updating error-prone to 2.4.0 (see google/error-prone#1106) I'm able to build the shadow jar successfully.