### PR TITLE
Add the go_package option to the protobuf files

### DIFF
--- a/proto/detection.proto
+++ b/proto/detection.proto
@@ -27,6 +27,7 @@ import "vulnerability.proto";
 option java_multiple_files = true;
 option java_outer_classname = "DetectionProtos";
 option java_package = "com.google.tsunami.proto";
+option go_package = "github.com/google/tsunami-security-scanner/proto";
 
 // Status of the vulnerability detection result.
 enum DetectionStatus {

--- a/proto/network.proto
+++ b/proto/network.proto
@@ -22,6 +22,7 @@ package tsunami.proto;
 option java_multiple_files = true;
 option java_outer_classname = "NetworkProtos";
 option java_package = "com.google.tsunami.proto";
+option go_package = "github.com/google/tsunami-security-scanner/proto";
 
 // The address family of an IP address.
 enum AddressFamily {

--- a/proto/network_service.proto
+++ b/proto/network_service.proto
@@ -25,6 +25,7 @@ import "software.proto";
 option java_multiple_files = true;
 option java_outer_classname = "NetworkServiceProtos";
 option java_package = "com.google.tsunami.proto";
+option go_package = "github.com/google/tsunami-security-scanner/proto";
 
 // General information about a network service running on a target.
 message NetworkService {

--- a/proto/reconnaissance.proto
+++ b/proto/reconnaissance.proto
@@ -25,6 +25,7 @@ import "network_service.proto";
 option java_multiple_files = true;
 option java_outer_classname = "ReconnaissanceProtos";
 option java_package = "com.google.tsunami.proto";
+option go_package = "github.com/google/tsunami-security-scanner/proto";
 
 // Detailed information about the scanning target.
 message TargetInfo {

--- a/proto/scan_results.proto
+++ b/proto/scan_results.proto
@@ -29,6 +29,7 @@ import "vulnerability.proto";
 option java_multiple_files = true;
 option java_outer_classname = "ScanResultsProtos";
 option java_package = "com.google.tsunami.proto";
+option go_package = "github.com/google/tsunami-security-scanner/proto";
 
 // Execution status of the scan.
 // NEXT ID: 5

--- a/proto/scan_target.proto
+++ b/proto/scan_target.proto
@@ -24,6 +24,7 @@ import "network.proto";
 option java_multiple_files = true;
 option java_outer_classname = "ScanTargetProtos";
 option java_package = "com.google.tsunami.proto";
+option go_package = "github.com/google/tsunami-security-scanner/proto";
 
 // The information about a scan target.
 message ScanTarget {

--- a/proto/software.proto
+++ b/proto/software.proto
@@ -22,6 +22,7 @@ package tsunami.proto;
 option java_multiple_files = true;
 option java_outer_classname = "SoftwareProtos";
 option java_package = "com.google.tsunami.proto";
+option go_package = "github.com/google/tsunami-security-scanner/proto";
 
 // The exact version of a software.
 message Version {

--- a/proto/vulnerability.proto
+++ b/proto/vulnerability.proto
@@ -22,6 +22,7 @@ package tsunami.proto;
 option java_multiple_files = true;
 option java_outer_classname = "VulnerabilityProtos";
 option java_package = "com.google.tsunami.proto";
+option go_package = "github.com/google/tsunami-security-scanner/proto";
 
 // Severity of a vulnerability.
 enum Severity {

--- a/proto/web_crawl.proto
+++ b/proto/web_crawl.proto
@@ -22,6 +22,7 @@ package tsunami.proto;
 option java_multiple_files = true;
 option java_outer_classname = "WebCrawlProtos";
 option java_package = "com.google.tsunami.proto";
+option go_package = "github.com/google/tsunami-security-scanner/proto";
 
 message CrawlConfig {
   // The crawler should only interact with web resources under certain scopes.


### PR DESCRIPTION
This option will soon be required to generate the Go code for the protobuf files.
Having valid protobuf files for Go would allow us to write report processors in this language.

See https://developers.google.com/protocol-buffers/docs/reference/go-generated#package
> Source .proto files should contain a go_package option specifying the full Go import path for the file. If there is no go_package option, the compiler will try to guess at one. A future release of the compiler will make the go_package option a requirement. The Go package name of generated code will be the last path component of the go_package option.

Test plan:
 Before:
   $ protoc vulnerability.proto --go_out=/tmp/
  2020/07/22 14:55:26 WARNING: Missing 'go_package' option in "vulnerability.proto",
  please specify it with the full Go package path as
  a future release of protoc-gen-go will require this be specified.
  See https://developers.google.com/protocol-buffers/docs/reference/go-generated#package for more information.

 After:
  $ protoc vulnerability.proto --go_out=/tmp/
 $ echo $?
 0