### PR TITLE
Method to set the input stream of a command

### DIFF
--- a/common/src/test/java/com/google/tsunami/common/command/CommandExecutorTest.java
+++ b/common/src/test/java/com/google/tsunami/common/command/CommandExecutorTest.java
@@ -83,4 +83,16 @@ public final class CommandExecutorTest {
     assertThat(executor.getError()).isEqualTo("1\n");
     assertThat(executor.getError()).isEqualTo("1\n");
   }
+
+  @Test
+  public void execute_writesInputIfSet()
+      throws IOException, InterruptedException, ExecutionException {
+    CommandExecutor executor = new CommandExecutor("/bin/sh", "-c", "read in; echo $in");
+    executor.setInput("1");
+
+    Process process = executor.execute();
+    process.waitFor();
+
+    assertThat(executor.getOutput()).isEqualTo("1\n");
+  }
 }


### PR DESCRIPTION
A lot of external programs are using stdin to pass data to the program
Expose a function `setInput()` to specify a custom string that is gonna be written to the process's standard input.
Test plan: added a new test and used the feature in one of my custom plugin.