### PR TITLE
Fix broken links from Orchestration to Future work

### DIFF
--- a/docs/orchestration.md
+++ b/docs/orchestration.md
@@ -4,7 +4,7 @@
 
 As of today, Tsunami follows a hardcoded 2-step process when scanning a publicly
 exposed network endpoint (see
-[Future Works](future_works.md#dynamic_orchestration) on the potential
+[Future Work](future_work.md#dynamic_orchestration) on the potential
 improvement on the workflow):
 
 *   **Reconnaissance**: In the first step, Tsunami identifies open ports and
@@ -86,7 +86,7 @@ detection logic could either be implemented as plain Java code, or as a separate
 binary / script using a different language like python or go. External binaries
 and scripts have to be executed as separate processes outside of Tsunami using
 Tsunami's command execution util. See
-[Future Works](future_works.md#multi_lang_plugins) for our design ideas of
+[Future Work](future_work.md#multi_lang_plugins) for our design ideas of
 making Tsunami plugins language agnostic.
 
 ### Detector Selection


### PR DESCRIPTION
Minor fix for these two links in the Orchestration docs over to two separate page anchors on the Future work page. The rename in [this commit](https://github.com/google/tsunami-security-scanner/commit/d565e01ede3ec20eb61c6d814fee8aa06719433a) is what broke the links, and I didn't see any other links to fix - please let me know if there's anything else y'all would like me to change.

Definitely appreciated learning about and getting to use Tsunami on my own, thanks for open sourcing this!