### PR TITLE
Publish docker images to docker hub

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -1,0 +1,35 @@
+---
+name: "Release the latest docker image"
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  push:
+    name: Build and push the Docker image
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Check out repository'
+        uses: actions/checkout@v2
+      - name: 'Login to Docker Hub'
+        uses: docker/login-action@v1
+        with:
+          username: ${{ "{{ secrets.DOCKERHUB_USERNAME }}" }}
+          password: ${{ "{{ secrets.DOCKERHUB_TOKEN }}" }}
+      - name: 'Build and push the docker image'
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: google/tsunami-security-scanner:latest
+      - name: 'Publish the README to Docker Hub'
+        uses: peter-evans/dockerhub-description@v2
+        with:
+          username: ${{ "{{ secrets.DOCKERHUB_USERNAME }}" }}
+          password: ${{ "{{ secrets.DOCKERHUB_TOKEN }}" }}
+          repository: google/tsunami-security-scanner
+          short-description: >
+            Tsunami is a general purpose network security scanner
+            with an extensible plugin system
+            for detecting high severity vulnerabilities with high confidence.


### PR DESCRIPTION
This adds a github action which will build and publish the docker image to docker hub.

Before merging, consider configuring the github repo with credentials for `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN`

I am also open to pinning the commit hashes for the use of the third party actions of `docker/login-action`, `docker/build-push-action `, `peter-evans/dockerhub-description`.