### PR TITLE
Fix syntax error in HowTo example

### DIFF
--- a/docs/howto.md
+++ b/docs/howto.md
@@ -95,7 +95,7 @@ a `http` or a `https` service.
 
 ```java
 // ...
-@ForServiceName(["http", "https"])
+@ForServiceName({"http", "https"})
 public final class WebFingerprinter implements ServiceFingerprinter {
   // ...
 }


### PR DESCRIPTION
The current `ForServiceName` annotation example leads to a build error, due to the square brackets. Passing an array of strings with curly braces seems to do the job.