### PR TITLE
Minor Dockerfile Improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN mkdir /usr/tsunami/plugins \
 WORKDIR /usr/repos/tsunami-security-scanner
 COPY . .
 RUN ./gradlew shadowJar \
-    && cp "$(find "./" -name 'tsunami-main-*-cli.jar')" /usr/tsunami/tsunami.jar \
+    && cp "$(find "./" -name "tsunami-main-*-cli.jar")" /usr/tsunami/tsunami.jar \
     && cp ./tsunami.yaml /usr/tsunami
 
 # Stage 2: Release

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,10 @@ FROM adoptopenjdk/openjdk13:debianslim
 
 # Install dependencies
 RUN apt-get update \
- && apt-get install -y --no-install-recommends git ca-certificates
+ && apt-get install -y --no-install-recommends git ca-certificates \
+ && rm -rf /var/lib/apt/lists/* \
+ && rm -rf /usr/share/doc && rm -rf /usr/share/man \
+ && apt-get clean
 
 WORKDIR /usr/tsunami/repos
 
@@ -21,7 +24,7 @@ RUN mkdir /usr/tsunami/plugins \
 WORKDIR /usr/repos/tsunami-security-scanner
 COPY . .
 RUN ./gradlew shadowJar \
-    && cp $(find "./" -name 'tsunami-main-*-cli.jar') /usr/tsunami/tsunami.jar \
+    && cp "$(find "./" -name 'tsunami-main-*-cli.jar')" /usr/tsunami/tsunami.jar \
     && cp ./tsunami.yaml /usr/tsunami
 
 # Stage 2: Release
@@ -30,6 +33,8 @@ FROM adoptopenjdk/openjdk13:debianslim-jre
 # Install dependencies
 RUN apt-get update \
     && apt-get install -y --no-install-recommends nmap ncrack ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -rf /usr/share/doc && rm -rf /usr/share/man \
     && apt-get clean \
     && mkdir logs/
 


### PR DESCRIPTION
https://docs.docker.com/develop/develop-images/dockerfile_best-practices/ :
```
In addition, cleaning up the apt cache and removing /var/lib/apt/lists helps keep the image size down.
Since the RUN statement starts with apt-get update, the package cache will always be refreshed prior to apt-get install.
```

https://github.com/hadolint/hadolint/wiki/SC2046 :
`Quote the find output which has another command's output that may contain white spaces to cause word splitting.`