### PR TITLE
Add CPE to network service data model

### DIFF
--- a/proto/network_service.proto
+++ b/proto/network_service.proto
@@ -52,6 +52,9 @@ message NetworkService {
   // Context information about this network service.
   ServiceContext service_context = 7;
 
+  // The cpe identifying the service
+  string cpe = 8;
+
   // TODO(magl): add ssl related information.
 }
 


### PR DESCRIPTION
The change introduces the CPE to the network service data model.

It has been tested to be used in plugins / detection reports similar to e.g. the service_name property.