### PR TITLE
Fix for issue #106 as discussed

### DIFF
--- a/common/src/main/java/com/google/tsunami/common/net/http/HttpClient.java
+++ b/common/src/main/java/com/google/tsunami/common/net/http/HttpClient.java
@@ -93,8 +93,6 @@ public abstract class HttpClient {
 
     public abstract Builder<T> setFollowRedirects(boolean followRedirects);
 
-    public abstract Builder<T> setTrustAllCertificates(boolean trustAllCertificates);
-
     public abstract Builder<T> setLogId(String logId);
 
     public abstract Builder<T> setConnectTimeout(Duration connectionTimeout);

--- a/common/src/main/java/com/google/tsunami/common/net/http/HttpClientCliOptions.java
+++ b/common/src/main/java/com/google/tsunami/common/net/http/HttpClientCliOptions.java
@@ -27,6 +27,7 @@ public final class HttpClientCliOptions implements CliOption {
 
   @Parameter(
       names = "--http-client-trust-all-certificates",
+      arity = 1,
       description = "Whether the HTTP client should trust all certificates on HTTPS traffic.")
   public Boolean trustAllCertificates;
 

--- a/common/src/main/java/com/google/tsunami/common/net/http/HttpClientModule.java
+++ b/common/src/main/java/com/google/tsunami/common/net/http/HttpClientModule.java
@@ -171,7 +171,7 @@ public final class HttpClientModule extends AbstractModule {
     if (httpClientConfigProperties.trustAllCertificates != null) {
       return httpClientConfigProperties.trustAllCertificates;
     }
-    return false;
+    return true;
   }
 
   @Provides

--- a/common/src/main/java/com/google/tsunami/common/net/http/OkHttpHttpClient.java
+++ b/common/src/main/java/com/google/tsunami/common/net/http/OkHttpHttpClient.java
@@ -375,12 +375,6 @@ final class OkHttpHttpClient extends HttpClient {
     }
 
     @Override
-    public OkHttpHttpClientBuilder setTrustAllCertificates(boolean trustAllCertificates) {
-      this.trustAllCertificates = trustAllCertificates;
-      return this;
-    }
-
-    @Override
     public OkHttpHttpClientBuilder setLogId(String logId) {
       this.logId = logId;
       return this;


### PR DESCRIPTION
As discussed in https://github.com/google/tsunami-security-scanner/issues/106, this PR introduces the following changes:
* Removed `setTrustAllCertificates` from the client since this was not meant to be customizable
* Set `setTrustAllCertificates` to true by default
* Ability for users to turn it off via the `--http-client-trust-all-certificates` flag. In order not to change its name, I just made the argument with arity 1 so that it's possible to set the flag to `true` or `false`.

**Important**: given we're deprecating the `setTrustAllCertificates` method, there are three old plugins that require updates. I will make a corresponding PR on https://github.com/google/tsunami-security-scanner-plugins