### PR TITLE
Fix typo in Tsunami documentation link

### DIFF
--- a/docs/howto/index.md
+++ b/docs/howto/index.md
@@ -14,7 +14,7 @@ This page contains information to get you started with your first contributions.
 
 ## Building and running Tsunami
 
-- [How to build and run Tsumami]({{ site.baseurl }}/howto/howto)
+- [How to build and run Tsunami]({{ site.baseurl }}/howto/howto)
 
 ## Writing plugins
 


### PR DESCRIPTION
I found a typo on the howto documentation page.
Tsumami -> Tsunami

Also. how can I contact someone about a publication that I made during my Engineering degree with my colleague? The article is a taxonomy of all the plugins that Tsunami used at the time of publishing(Until July 2023) and is available at: https://ieeexplore.ieee.org/document/10224998