### PR TITLE
fix(http): add SSRF redirect protection to OkHttp client

### DIFF
--- a/common/src/main/java/com/google/tsunami/common/net/http/HttpClientModule.java
+++ b/common/src/main/java/com/google/tsunami/common/net/http/HttpClientModule.java
@@ -124,7 +124,8 @@ public final class HttpClientModule extends AbstractModule {
             .writeTimeout(Duration.ofSeconds(connectTimeoutSeconds))
             .connectionPool(connectionPool)
             .dispatcher(dispatcher)
-            .followRedirects(followRedirects);
+            .followRedirects(followRedirects)
+            .addNetworkInterceptor(new SsrfRedirectInterceptor());
     if (trustAllCertificates) {
       clientBuilder
           .sslSocketFactory(trustAllCertsSocketFactory, TRUST_ALL_CERTS_MANAGER)

--- a/common/src/main/java/com/google/tsunami/common/net/http/SsrfRedirectInterceptor.java
+++ b/common/src/main/java/com/google/tsunami/common/net/http/SsrfRedirectInterceptor.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.tsunami.common.net.http;
+
+import com.google.common.collect.ImmutableSet;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import okhttp3.Interceptor;
+import okhttp3.Response;
+
+final class SsrfRedirectInterceptor implements Interceptor {
+
+  private static final ImmutableSet<Integer> REDIRECT_CODES =
+      ImmutableSet.of(301, 302, 303, 307, 308);
+
+  private static final ImmutableSet<String> BLOCKED_HOSTNAMES =
+      ImmutableSet.of("metadata.google.internal");
+
+  @Override
+  public Response intercept(Chain chain) throws IOException {
+    Response response = chain.proceed(chain.request());
+
+    if (!REDIRECT_CODES.contains(response.code())) {
+      return response;
+    }
+
+    String location = response.header("Location");
+    if (location == null) {
+      return response;
+    }
+
+    okhttp3.HttpUrl redirectUrl = response.request().url().resolve(location);
+    if (redirectUrl == null) {
+      return response;
+    }
+
+    String host = redirectUrl.host();
+
+    if (BLOCKED_HOSTNAMES.contains(host.toLowerCase(java.util.Locale.ROOT))) {
+      response.close();
+      throw new IOException(
+          "SSRF protection: redirect to blocked hostname " + host + " is not allowed");
+    }
+
+    InetAddress addr;
+    try {
+      addr = InetAddress.getByName(host);
+    } catch (UnknownHostException e) {
+      return response;
+    }
+
+    if (isBlockedAddress(addr)) {
+      response.close();
+      throw new IOException(
+          "SSRF protection: redirect to blocked address " + addr.getHostAddress()
+              + " is not allowed");
+    }
+
+    return response;
+  }
+
+  static boolean isBlockedAddress(InetAddress addr) {
+    return addr.isLoopbackAddress()
+        || addr.isLinkLocalAddress()
+        || addr.isSiteLocalAddress()
+        || isUniqueLocal(addr);
+  }
+
+  private static boolean isUniqueLocal(InetAddress addr) {
+    byte[] bytes = addr.getAddress();
+    if (bytes.length == 16) {
+      // fc00::/7
+      return (bytes[0] & 0xFE) == 0xFC;
+    }
+    return false;
+  }
+}

--- a/common/src/test/java/com/google/tsunami/common/net/http/SsrfRedirectInterceptorTest.java
+++ b/common/src/test/java/com/google/tsunami/common/net/http/SsrfRedirectInterceptorTest.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.tsunami.common.net.http;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import okhttp3.OkHttpClient;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public final class SsrfRedirectInterceptorTest {
+
+  private final MockWebServer mockWebServer = new MockWebServer();
+
+  private final OkHttpClient client =
+      new OkHttpClient.Builder()
+          .followRedirects(true)
+          .addNetworkInterceptor(new SsrfRedirectInterceptor())
+          .build();
+
+  @After
+  public void tearDown() throws IOException {
+    mockWebServer.shutdown();
+  }
+
+  @Test
+  public void nonRedirectResponse_isPassedThrough() throws Exception {
+    mockWebServer.enqueue(new MockResponse().setResponseCode(200).setBody("ok"));
+    mockWebServer.start();
+
+    okhttp3.Response response =
+        client.newCall(new okhttp3.Request.Builder().url(mockWebServer.url("/")).build()).execute();
+
+    assertThat(response.code()).isEqualTo(200);
+    response.close();
+  }
+
+  @Test
+  public void redirectToPublicIp_isAllowed() throws Exception {
+    mockWebServer.enqueue(
+        new MockResponse().setResponseCode(302).setHeader("Location", "http://8.8.8.8/"));
+    mockWebServer.start();
+
+    // The redirect itself is allowed; the connection to 8.8.8.8 may fail but that's fine.
+    // We just verify the interceptor doesn't throw.
+    try {
+      client.newCall(new okhttp3.Request.Builder().url(mockWebServer.url("/")).build()).execute();
+    } catch (IOException e) {
+      // Connection refused to 8.8.8.8 is expected in test, but SSRF block message is not.
+      assertThat(e.getMessage()).doesNotContain("SSRF protection");
+    }
+  }
+
+  @Test
+  public void redirectToLoopback_isBlocked() throws Exception {
+    mockWebServer.enqueue(
+        new MockResponse().setResponseCode(302).setHeader("Location", "http://127.0.0.1/"));
+    mockWebServer.start();
+
+    IOException exception =
+        assertThrows(
+            IOException.class,
+            () ->
+                client
+                    .newCall(
+                        new okhttp3.Request.Builder().url(mockWebServer.url("/test")).build())
+                    .execute());
+
+    assertThat(exception.getMessage()).contains("SSRF protection");
+  }
+
+  @Test
+  public void redirectToMetadataIp_isBlocked() throws Exception {
+    mockWebServer.enqueue(
+        new MockResponse()
+            .setResponseCode(302)
+            .setHeader("Location", "http://169.254.169.254/latest/meta-data/"));
+    mockWebServer.start();
+
+    IOException exception =
+        assertThrows(
+            IOException.class,
+            () ->
+                client
+                    .newCall(
+                        new okhttp3.Request.Builder().url(mockWebServer.url("/test")).build())
+                    .execute());
+
+    assertThat(exception.getMessage()).contains("SSRF protection");
+  }
+
+  @Test
+  public void redirectToMetadataHostname_isBlocked() throws Exception {
+    mockWebServer.enqueue(
+        new MockResponse()
+            .setResponseCode(302)
+            .setHeader("Location", "http://metadata.google.internal/computeMetadata/v1/"));
+    mockWebServer.start();
+
+    IOException exception =
+        assertThrows(
+            IOException.class,
+            () ->
+                client
+                    .newCall(
+                        new okhttp3.Request.Builder().url(mockWebServer.url("/test")).build())
+                    .execute());
+
+    assertThat(exception.getMessage()).contains("SSRF protection");
+  }
+
+  @Test
+  public void redirectToPrivateNetwork10_isBlocked() throws Exception {
+    mockWebServer.enqueue(
+        new MockResponse().setResponseCode(301).setHeader("Location", "http://10.0.0.1/"));
+    mockWebServer.start();
+
+    IOException exception =
+        assertThrows(
+            IOException.class,
+            () ->
+                client
+                    .newCall(
+                        new okhttp3.Request.Builder().url(mockWebServer.url("/test")).build())
+                    .execute());
+
+    assertThat(exception.getMessage()).contains("SSRF protection");
+  }
+
+  @Test
+  public void redirectToPrivateNetwork192_isBlocked() throws Exception {
+    mockWebServer.enqueue(
+        new MockResponse().setResponseCode(307).setHeader("Location", "http://192.168.1.1/"));
+    mockWebServer.start();
+
+    IOException exception =
+        assertThrows(
+            IOException.class,
+            () ->
+                client
+                    .newCall(
+                        new okhttp3.Request.Builder().url(mockWebServer.url("/test")).build())
+                    .execute());
+
+    assertThat(exception.getMessage()).contains("SSRF protection");
+  }
+
+  @Test
+  public void redirectToPrivateNetwork172_isBlocked() throws Exception {
+    mockWebServer.enqueue(
+        new MockResponse().setResponseCode(308).setHeader("Location", "http://172.16.0.1/"));
+    mockWebServer.start();
+
+    IOException exception =
+        assertThrows(
+            IOException.class,
+            () ->
+                client
+                    .newCall(
+                        new okhttp3.Request.Builder().url(mockWebServer.url("/test")).build())
+                    .execute());
+
+    assertThat(exception.getMessage()).contains("SSRF protection");
+  }
+
+  @Test
+  public void isBlockedAddress_loopback() throws Exception {
+    assertThat(SsrfRedirectInterceptor.isBlockedAddress(InetAddress.getByName("127.0.0.1")))
+        .isTrue();
+    assertThat(SsrfRedirectInterceptor.isBlockedAddress(InetAddress.getByName("::1"))).isTrue();
+  }
+
+  @Test
+  public void isBlockedAddress_linkLocal() throws Exception {
+    assertThat(SsrfRedirectInterceptor.isBlockedAddress(InetAddress.getByName("169.254.169.254")))
+        .isTrue();
+    assertThat(SsrfRedirectInterceptor.isBlockedAddress(InetAddress.getByName("fe80::1")))
+        .isTrue();
+  }
+
+  @Test
+  public void isBlockedAddress_siteLocal() throws Exception {
+    assertThat(SsrfRedirectInterceptor.isBlockedAddress(InetAddress.getByName("10.0.0.1")))
+        .isTrue();
+    assertThat(SsrfRedirectInterceptor.isBlockedAddress(InetAddress.getByName("172.16.0.1")))
+        .isTrue();
+    assertThat(SsrfRedirectInterceptor.isBlockedAddress(InetAddress.getByName("192.168.1.1")))
+        .isTrue();
+  }
+
+  @Test
+  public void isBlockedAddress_uniqueLocalIpv6() throws Exception {
+    assertThat(SsrfRedirectInterceptor.isBlockedAddress(InetAddress.getByName("fd00::1")))
+        .isTrue();
+    assertThat(SsrfRedirectInterceptor.isBlockedAddress(InetAddress.getByName("fc00::1")))
+        .isTrue();
+  }
+
+  @Test
+  public void isBlockedAddress_publicIp_notBlocked() throws Exception {
+    assertThat(SsrfRedirectInterceptor.isBlockedAddress(InetAddress.getByName("8.8.8.8")))
+        .isFalse();
+    assertThat(
+            SsrfRedirectInterceptor.isBlockedAddress(
+                InetAddress.getByName("2001:4860:4860::8888")))
+        .isFalse();
+  }
+}


### PR DESCRIPTION
## Summary

Add an OkHttp network interceptor that blocks HTTP redirects to
internal and cloud metadata endpoints, preventing SSRF attacks
where an attacker-controlled scan target redirects the scanner to
sensitive addresses.

## Problem

The OkHttp client follows redirects by default
(`DEFAULT_FOLLOW_REDIRECTS = true`) with no destination validation.
A malicious scan target can return a 302 redirect to
`http://169.254.169.254/latest/meta-data/` and the scanner will
silently follow it, potentially exfiltrating cloud IAM credentials
from the host VM.

## Changes

- **`SsrfRedirectInterceptor.java`** (new): Network interceptor
  that inspects redirect responses (301/302/303/307/308) and blocks
  `Location` targets resolving to loopback, link-local, site-local,
  IPv6 unique-local addresses, and `metadata.google.internal`
- **`HttpClientModule.java`**: Wire interceptor into the
  `OkHttpClient.Builder`
- **`SsrfRedirectInterceptorTest.java`** (new): Unit tests covering
  all blocked ranges, public IP passthrough, hostname blocking, and
  non-redirect passthrough

## Notes

- No new dependencies — uses `InetAddress` built-in checks and
  Guava `ImmutableSet`
- Only redirects are validated; original scan requests are
  unaffected
- Non-redirect responses pass through untouched

Refs #153