### PR TITLE
Fix: Hardening DefaultConnectionFactory against Blind SSRF via redirects

### DIFF
--- a/common/src/main/java/com/google/tsunami/common/net/http/javanet/DefaultConnectionFactory.java
+++ b/common/src/main/java/com/google/tsunami/common/net/http/javanet/DefaultConnectionFactory.java
@@ -48,6 +48,10 @@ public class DefaultConnectionFactory implements ConnectionFactory {
   @Override
   public HttpURLConnection openConnection(String url) throws IOException {
     HttpURLConnection connection = (HttpURLConnection) new URL(url).openConnection();
+
+    // Prevent blind SSRF by disabling automatic redirects
+    connection.setInstanceFollowRedirects(false);
+
     connection.setConnectTimeout((int) connectTimeout.toMillis());
     connection.setReadTimeout((int) readTimeout.toMillis());
 


### PR DESCRIPTION
This PR disables automatic redirect following in HttpURLConnection. As identified in the Tsunami architecture, allowing automatic redirects can be weaponized to target internal metadata services (169.254.169.254) or local gRPC language servers (127.0.0.1) exposed via RemoteVulnDetectorLoadingModule.