### PR TITLE
Cap HTTP response body size to bound adversarial-target memory use (CWE-770)

### DIFF
--- a/common/src/main/java/com/google/tsunami/common/net/http/HttpClientCliOptions.java
+++ b/common/src/main/java/com/google/tsunami/common/net/http/HttpClientCliOptions.java
@@ -65,12 +65,26 @@ public final class HttpClientCliOptions implements CliOption {
       description = "User-Agent to use in HTTP requests.")
   public String userAgent = HttpClient.TSUNAMI_USER_AGENT;
 
+  @Parameter(
+      names = "--http-client-max-response-body-mb",
+      description =
+          "Maximum size in megabytes of an HTTP response body the client will buffer in memory."
+              + " Responses larger than this cause the affected probe to fail with an IOException"
+              + " while the surrounding scan continues. Defaults to 100 MB.")
+  Integer maxResponseBodyMb;
+
   @Override
   public void validate() {
     validateTimeout("--http-client-call-timeout-seconds", callTimeoutSeconds);
     validateTimeout("--http-client-connect-timeout-seconds", connectTimeoutSeconds);
     validateTimeout("--http-client-read-timeout-seconds", readTimeoutSeconds);
     validateTimeout("--http-client-write-timeout-seconds", writeTimeoutSeconds);
+    if (maxResponseBodyMb != null && maxResponseBodyMb <= 0) {
+      throw new ParameterException(
+          String.format(
+              "--http-client-max-response-body-mb must be positive, received %d.",
+              maxResponseBodyMb));
+    }
   }
 
   private static void validateTimeout(String flagName, @Nullable Integer value) {

--- a/common/src/main/java/com/google/tsunami/common/net/http/HttpClientConfigProperties.java
+++ b/common/src/main/java/com/google/tsunami/common/net/http/HttpClientConfigProperties.java
@@ -50,4 +50,11 @@ public final class HttpClientConfigProperties {
    * more details.
    */
   Integer writeTimeoutSeconds;
+
+  /**
+   * Maximum size in megabytes of an HTTP response body the client will buffer in memory. Responses
+   * larger than this cause the affected probe to fail with an IOException while the surrounding
+   * scan continues. Defaults to 100 MB when unset.
+   */
+  Integer maxResponseBodyMb;
 }

--- a/common/src/main/java/com/google/tsunami/common/net/http/HttpClientModule.java
+++ b/common/src/main/java/com/google/tsunami/common/net/http/HttpClientModule.java
@@ -141,9 +141,16 @@ public final class HttpClientModule extends AbstractModule {
       ConnectionFactory connectionFactory,
       @LogId String logId,
       @ConnectTimeout Duration connectTimeout,
-      @UserAgent String userAgent) {
+      @UserAgent String userAgent,
+      @MaxResponseBodyBytes long maxResponseBodyBytes) {
     return new OkHttpHttpClient(
-        okHttpClient, trustAllCertificates, connectionFactory, logId, connectTimeout, userAgent);
+        okHttpClient,
+        trustAllCertificates,
+        connectionFactory,
+        logId,
+        connectTimeout,
+        userAgent,
+        maxResponseBodyBytes);
   }
 
   @Provides
@@ -271,6 +278,23 @@ public final class HttpClientModule extends AbstractModule {
     return HttpClient.TSUNAMI_USER_AGENT;
   }
 
+  @Provides
+  @MaxResponseBodyBytes
+  long provideMaxResponseBodyBytes(
+      HttpClientCliOptions httpClientCliOptions,
+      HttpClientConfigProperties httpClientConfigProperties) {
+    Integer megabytes = null;
+    if (httpClientCliOptions.maxResponseBodyMb != null) {
+      megabytes = httpClientCliOptions.maxResponseBodyMb;
+    } else if (httpClientConfigProperties.maxResponseBodyMb != null) {
+      megabytes = httpClientConfigProperties.maxResponseBodyMb;
+    }
+    if (megabytes == null) {
+      return OkHttpHttpClient.DEFAULT_MAX_RESPONSE_BODY_BYTES;
+    }
+    return ((long) megabytes) * 1024L * 1024L;
+  }
+
   @Qualifier
   @Retention(RetentionPolicy.RUNTIME)
   @Target({ElementType.PARAMETER, ElementType.METHOD, ElementType.FIELD})
@@ -325,6 +349,11 @@ public final class HttpClientModule extends AbstractModule {
   @Retention(RetentionPolicy.RUNTIME)
   @Target({ElementType.PARAMETER, ElementType.METHOD, ElementType.FIELD})
   @interface UserAgent {}
+
+  @Qualifier
+  @Retention(RetentionPolicy.RUNTIME)
+  @Target({ElementType.PARAMETER, ElementType.METHOD, ElementType.FIELD})
+  @interface MaxResponseBodyBytes {}
 
   /** Builder for {@link HttpClientModule}. */
   public static final class Builder {

--- a/common/src/main/java/com/google/tsunami/common/net/http/OkHttpHttpClient.java
+++ b/common/src/main/java/com/google/tsunami/common/net/http/OkHttpHttpClient.java
@@ -30,7 +30,9 @@ import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.protobuf.ByteString;
 import com.google.tsunami.common.net.http.javanet.ConnectionFactory;
 import com.google.tsunami.proto.NetworkService;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.time.Duration;
 import java.util.List;
@@ -46,6 +48,8 @@ import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
+import okio.Buffer;
+import okio.BufferedSource;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
@@ -55,12 +59,19 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 final class OkHttpHttpClient extends HttpClient {
   private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
 
+  // Default ceiling on response body bytes a single HTTP call may buffer in memory. Targets
+  // probed by the scanner are by definition adversarial, so an unbounded read is a remote DoS
+  // primitive (CWE-770 / CWE-400). 100 MB comfortably accommodates any HTML/JSON payload a
+  // detector should ever need while bounding the worst-case allocation per call.
+  static final long DEFAULT_MAX_RESPONSE_BODY_BYTES = 100L * 1024 * 1024;
+
   private final OkHttpClient okHttpClient;
   private final boolean trustAllCertificates;
   private final ConnectionFactory connectionFactory;
   private final String logId;
   private final Duration connectionTimeout;
   private final String userAgent;
+  private final long maxResponseBodyBytes;
 
   OkHttpHttpClient(
       OkHttpClient okHttpClient,
@@ -69,12 +80,31 @@ final class OkHttpHttpClient extends HttpClient {
       String logId,
       Duration connectionTimeout,
       String userAgent) {
+    this(
+        okHttpClient,
+        trustAllCertificates,
+        connectionFactory,
+        logId,
+        connectionTimeout,
+        userAgent,
+        DEFAULT_MAX_RESPONSE_BODY_BYTES);
+  }
+
+  OkHttpHttpClient(
+      OkHttpClient okHttpClient,
+      boolean trustAllCertificates,
+      ConnectionFactory connectionFactory,
+      String logId,
+      Duration connectionTimeout,
+      String userAgent,
+      long maxResponseBodyBytes) {
     this.okHttpClient = checkNotNull(okHttpClient);
     this.trustAllCertificates = trustAllCertificates;
     this.connectionFactory = checkNotNull(connectionFactory);
     this.logId = logId;
     this.connectionTimeout = connectionTimeout;
     this.userAgent = isNullOrEmpty(userAgent) ? TSUNAMI_USER_AGENT : userAgent;
+    this.maxResponseBodyBytes = maxResponseBodyBytes;
   }
 
   /**
@@ -134,7 +164,7 @@ final class OkHttpHttpClient extends HttpClient {
     return HttpResponse.builder()
         .setStatus(HttpStatus.fromCode(responseCode))
         .setHeaders(responseHeadersBuilder.build())
-        .setBodyBytes(ByteString.readFrom(connection.getInputStream()))
+        .setBodyBytes(readStreamWithCap(connection.getInputStream(), httpRequest.url()))
         .build();
   }
 
@@ -310,7 +340,7 @@ final class OkHttpHttpClient extends HttpClient {
         mediaType, httpRequest.requestBody().orElse(ByteString.EMPTY).toByteArray());
   }
 
-  private static HttpResponse parseResponse(Response okResponse) throws IOException {
+  private HttpResponse parseResponse(Response okResponse) throws IOException {
     logger.atInfo().log(
         "Received HTTP response with code '%d' for request to '%s'.",
         okResponse.code(), okResponse.request().url());
@@ -322,9 +352,63 @@ final class OkHttpHttpClient extends HttpClient {
             .setResponseUrl(okResponse.request().url());
     if (!okResponse.request().method().equals(HttpMethod.HEAD.name())
         && okResponse.body() != null) {
-      httpResponseBuilder.setBodyBytes(ByteString.copyFrom(okResponse.body().bytes()));
+      httpResponseBuilder.setBodyBytes(
+          readBodyWithCap(okResponse.body(), okResponse.request().url().toString()));
     }
     return httpResponseBuilder.build();
+  }
+
+  // Reads an OkHttp response body with a hard byte ceiling. Bypasses ResponseBody.bytes()
+  // because that buffers the entire body and only enforces a 2 GB ceiling on bodies whose
+  // Content-Length is advertised (a malicious chunked-encoded peer with no Content-Length
+  // bypasses it entirely).
+  private ByteString readBodyWithCap(ResponseBody body, String requestUrl) throws IOException {
+    long advertised = body.contentLength();
+    if (advertised > maxResponseBodyBytes) {
+      throw new IOException(
+          String.format(
+              "Response body for %s advertised %d bytes, exceeds cap of %d bytes.",
+              requestUrl, advertised, maxResponseBodyBytes));
+    }
+    Buffer sink = new Buffer();
+    long total = 0L;
+    try (BufferedSource source = body.source()) {
+      long n;
+      while ((n = source.read(sink, 8192L)) != -1L) {
+        total += n;
+        if (total > maxResponseBodyBytes) {
+          sink.clear();
+          throw new IOException(
+              String.format(
+                  "Response body for %s exceeds cap of %d bytes (read so far: %d).",
+                  requestUrl, maxResponseBodyBytes, total));
+        }
+      }
+    }
+    return ByteString.copyFrom(sink.readByteArray());
+  }
+
+  // Reads from a raw InputStream (used by sendAsIs, which goes through HttpURLConnection
+  // rather than OkHttp). Strictly worse than the OkHttp path absent a cap because the
+  // underlying ByteString.readFrom drains until EOF with no ceiling whatsoever.
+  private ByteString readStreamWithCap(InputStream stream, String requestUrl) throws IOException {
+    ByteArrayOutputStream sink = new ByteArrayOutputStream();
+    byte[] buffer = new byte[8192];
+    long total = 0L;
+    try (InputStream in = stream) {
+      int read;
+      while ((read = in.read(buffer)) != -1) {
+        total += read;
+        if (total > maxResponseBodyBytes) {
+          throw new IOException(
+              String.format(
+                  "Response body for %s exceeds cap of %d bytes (read so far: %d).",
+                  requestUrl, maxResponseBodyBytes, total));
+        }
+        sink.write(buffer, 0, read);
+      }
+    }
+    return ByteString.copyFrom(sink.toByteArray());
   }
 
   private static HttpHeaders convertHeaders(Headers headers) {
@@ -357,6 +441,7 @@ final class OkHttpHttpClient extends HttpClient {
     private String logId;
     private Duration connectionTimeout;
     private String userAgent;
+    private long maxResponseBodyBytes;
 
     private OkHttpHttpClientBuilder(OkHttpHttpClient okHttpHttpClient) {
       this.okHttpClient = okHttpHttpClient.okHttpClient;
@@ -366,6 +451,7 @@ final class OkHttpHttpClient extends HttpClient {
       this.logId = okHttpHttpClient.logId;
       this.connectionTimeout = okHttpHttpClient.connectionTimeout;
       this.userAgent = okHttpHttpClient.userAgent;
+      this.maxResponseBodyBytes = okHttpHttpClient.maxResponseBodyBytes;
     }
 
     @Override
@@ -392,6 +478,12 @@ final class OkHttpHttpClient extends HttpClient {
       return this;
     }
 
+    @CanIgnoreReturnValue
+    public OkHttpHttpClientBuilder setMaxResponseBodyBytes(long maxResponseBodyBytes) {
+      this.maxResponseBodyBytes = maxResponseBodyBytes;
+      return this;
+    }
+
     @Override
     public OkHttpHttpClient build() {
       return new OkHttpHttpClient(
@@ -400,7 +492,8 @@ final class OkHttpHttpClient extends HttpClient {
           connectionFactory,
           logId,
           connectionTimeout,
-          userAgent);
+          userAgent,
+          maxResponseBodyBytes);
     }
   }
 }

--- a/common/src/test/java/com/google/tsunami/common/net/http/OkHttpHttpClientTest.java
+++ b/common/src/test/java/com/google/tsunami/common/net/http/OkHttpHttpClientTest.java
@@ -711,6 +711,63 @@ public final class OkHttpHttpClientTest {
   }
 
   @Test
+  public void send_whenResponseBodyExceedsCap_throwsIOException() throws IOException {
+    String responseBody = "0123456789ABCDEF response body that comfortably exceeds 16 bytes";
+    mockWebServer.enqueue(
+        new MockResponse()
+            .setResponseCode(HttpStatus.OK.code())
+            .setHeader(CONTENT_TYPE, MediaType.PLAIN_TEXT_UTF_8.toString())
+            .setBody(responseBody));
+    mockWebServer.start();
+
+    HttpClient cappedClient = buildCappedClient(httpClient, 16L);
+
+    String requestUrl = mockWebServer.url("/test/get-oversized").toString();
+    IOException thrown =
+        assertThrows(
+            IOException.class,
+            () -> cappedClient.send(get(requestUrl).withEmptyHeaders().build()));
+    assertThat(thrown).hasMessageThat().contains("exceeds cap of 16 bytes");
+  }
+
+  @Test
+  public void sendAsIs_whenResponseBodyExceedsCap_throwsIOException() throws IOException {
+    mockWebServer.setDispatcher(new SendAsIsTestDispatcher());
+    mockWebServer.start();
+
+    HttpClient cappedClient = buildCappedClient(httpClient, 8L);
+
+    HttpUrl baseUrl = mockWebServer.url("/");
+    String requestUrl =
+        new URL(baseUrl.scheme(), baseUrl.host(), baseUrl.port(), "/send-as-is/oversized")
+            .toString();
+
+    IOException thrown =
+        assertThrows(
+            IOException.class,
+            () -> cappedClient.sendAsIs(get(requestUrl).withEmptyHeaders().build()));
+    assertThat(thrown).hasMessageThat().contains("exceeds cap of 8 bytes");
+  }
+
+  @Test
+  public void send_whenResponseBodyWithinCap_returnsExpectedHttpResponse() throws IOException {
+    String responseBody = "tiny";
+    mockWebServer.enqueue(
+        new MockResponse()
+            .setResponseCode(HttpStatus.OK.code())
+            .setHeader(CONTENT_TYPE, MediaType.PLAIN_TEXT_UTF_8.toString())
+            .setBody(responseBody));
+    mockWebServer.start();
+
+    HttpClient cappedClient = buildCappedClient(httpClient, 16L);
+
+    String requestUrl = mockWebServer.url("/test/within-cap").toString();
+    HttpResponse response = cappedClient.send(get(requestUrl).withEmptyHeaders().build());
+
+    assertThat(response.bodyBytes()).hasValue(ByteString.copyFrom(responseBody, UTF_8));
+  }
+
+  @Test
   public void send_default_userAgent() throws IOException, InterruptedException {
     String responseBody = "test response";
     mockWebServer.enqueue(
@@ -759,6 +816,16 @@ public final class OkHttpHttpClientTest {
     httpClient.send(get(baseUrl.toString()).withEmptyHeaders().build());
 
     assertThat(mockWebServer.takeRequest().getHeader(USER_AGENT)).isEqualTo(userAgentOverride);
+  }
+
+  // Returns a copy of the supplied client whose response-body cap is set to {@code capBytes}.
+  // The test only exercises the OkHttp builder, but the cast is safe because the injected
+  // HttpClient is always backed by OkHttpHttpClientBuilder in this module.
+  @SuppressWarnings("unchecked")
+  private static HttpClient buildCappedClient(HttpClient client, long capBytes) {
+    OkHttpHttpClient.OkHttpHttpClientBuilder builder =
+        (OkHttpHttpClient.OkHttpHttpClientBuilder) (HttpClient.Builder<?>) client.modify();
+    return builder.setMaxResponseBodyBytes(capBytes).build();
   }
 
   private MockWebServer startMockWebServerWithSsl(InetAddress serverAddress)

--- a/plugin_server/py/common/net/http/requests_http_client.py
+++ b/plugin_server/py/common/net/http/requests_http_client.py
@@ -25,6 +25,12 @@ _DEFAULT_POOL_MAXSIZE = 10
 _DEFAULT_MAX_WORKERS = 64
 _TIMEOUT_SEC = 10
 _VERIFY_SSL = True
+# Default ceiling on response body bytes a single HTTP call may buffer in memory. Targets
+# probed by the scanner are by definition adversarial, so an unbounded read is a remote DoS
+# primitive (CWE-770 / CWE-400). 100 MB comfortably accommodates any HTML/JSON payload a
+# detector should ever need while bounding the worst-case allocation per call.
+_DEFAULT_MAX_RESPONSE_BODY_BYTES = 100 * 1024 * 1024
+_READ_CHUNK_BYTES = 8192
 
 
 class RequestsHttpClient(HttpClient):
@@ -51,6 +57,7 @@ class RequestsHttpClient(HttpClient):
       max_workers: Optional[int],
       timeout_sec: Optional[float],
       verify_ssl: Optional[bool],
+      max_response_body_bytes: int = _DEFAULT_MAX_RESPONSE_BODY_BYTES,
   ):
     self.session = session
     self.allow_redirects = allow_redirects
@@ -58,6 +65,7 @@ class RequestsHttpClient(HttpClient):
     self.max_workers = max_workers
     self.timeout_sec = timeout_sec
     self.verify_ssl = verify_ssl
+    self.max_response_body_bytes = max_response_body_bytes
 
   def get_log_id(self) -> str:
     return self.log_id
@@ -75,6 +83,11 @@ class RequestsHttpClient(HttpClient):
         verify=self.verify_ssl,
         timeout=self.timeout_sec,
         allow_redirects=self.allow_redirects,
+        # stream=True keeps the body off the response object so we can drain it
+        # ourselves with a hard byte ceiling. Without it, requests buffers the
+        # entire body inside session.send() and a malicious chunked peer can OOM
+        # the process before we ever return.
+        stream=True,
     )
     return self._parse_response(resp)
 
@@ -104,6 +117,7 @@ class RequestsHttpClient(HttpClient):
     return headers_builder.build()
 
   def _parse_response(self, res: requests.Response) -> HttpResponse:
+    body = self._read_body_with_cap(res)
     response_header = self._build_response_headers(res.headers)
     status = HttpStatus.from_code(res.status_code)
     return (
@@ -111,9 +125,46 @@ class RequestsHttpClient(HttpClient):
         .set_url(res.url)
         .set_status(status)
         .set_headers(response_header)
-        .set_response_body(res.content)
+        .set_response_body(body)
         .build()
     )
+
+  def _read_body_with_cap(self, res: requests.Response) -> bytes:
+    """Drain a streamed response body with a hard byte ceiling.
+
+    Targets probed by Tsunami are adversarial by definition; a malicious peer
+    can serve an unbounded chunked body and force the process OOM. This method
+    reads in 8 KiB chunks and aborts the moment the cap is exceeded, closing
+    the underlying connection so the peer cannot keep the socket alive.
+    """
+    advertised = res.headers.get('Content-Length')
+    if advertised is not None:
+      try:
+        if int(advertised) > self.max_response_body_bytes:
+          raise IOError(
+              'Response body for %s advertised %s bytes, exceeds cap of %d'
+              ' bytes.'
+              % (res.url, advertised, self.max_response_body_bytes)
+          )
+      except ValueError:
+        pass
+
+    buf = bytearray()
+    try:
+      for chunk in res.iter_content(
+          chunk_size=_READ_CHUNK_BYTES, decode_unicode=False
+      ):
+        if not chunk:
+          continue
+        buf.extend(chunk)
+        if len(buf) > self.max_response_body_bytes:
+          raise IOError(
+              'Response body for %s exceeds cap of %d bytes (read so far: %d).'
+              % (res.url, self.max_response_body_bytes, len(buf))
+          )
+    finally:
+      res.close()
+    return bytes(buf)
 
   async def _prepare_future(
       self,
@@ -131,6 +182,7 @@ class RequestsHttpClient(HttpClient):
             verify=self.verify_ssl,
             timeout=self.timeout_sec,
             allow_redirects=self.allow_redirects,
+            stream=True,
         ),
     )
     return await future
@@ -193,6 +245,8 @@ class RequestsHttpClientBuilder(Builder):
     self.pool_connections = _DEFAULT_POOL_CONNECTIONS
     # Maximum number of connections to save in the pool.
     self.pool_maxsize = _DEFAULT_POOL_MAXSIZE
+    # Maximum response body bytes the client will buffer in memory.
+    self.max_response_body_bytes = _DEFAULT_MAX_RESPONSE_BODY_BYTES
 
   def set_allow_redirects(
       self, allow_redirects: bool
@@ -226,6 +280,12 @@ class RequestsHttpClientBuilder(Builder):
     self.verify_ssl = verify_ssl
     return self
 
+  def set_max_response_body_bytes(
+      self, max_response_body_bytes: int
+  ) -> 'RequestsHttpClientBuilder':
+    self.max_response_body_bytes = max_response_body_bytes
+    return self
+
   def build(self) -> RequestsHttpClient:
     session = requests.Session()
     adapter = HostResolverHttpAdapter(
@@ -241,4 +301,5 @@ class RequestsHttpClientBuilder(Builder):
         max_workers=self.max_workers,
         timeout_sec=self.timeout_sec,
         verify_ssl=self.verify_ssl,
+        max_response_body_bytes=self.max_response_body_bytes,
     )

--- a/plugin_server/py/common/net/http/requests_http_client_test.py
+++ b/plugin_server/py/common/net/http/requests_http_client_test.py
@@ -295,6 +295,53 @@ class RequestsHttpClientTest(absltest.TestCase):
     )
     self._assert_response_is_expected(response, expected)
 
+  @requests_mock.mock()
+  def test_send_when_response_body_exceeds_cap_raises_io_error(self, mock):
+    url = 'http://example.com/get/oversized'
+    body = b'A' * 1024
+    mock.register_uri(HttpMethod.GET, url, content=body)
+    capped_client = (
+        RequestsHttpClientBuilder().set_max_response_body_bytes(16).build()
+    )
+    with self.assertRaisesRegex(IOError, 'exceeds cap of 16 bytes'):
+      capped_client.send(
+          HttpRequest().get(url).with_empty_headers().build()
+      )
+
+  @requests_mock.mock()
+  def test_send_when_advertised_content_length_exceeds_cap_raises_io_error(
+      self, mock
+  ):
+    url = 'http://example.com/get/oversized-advertised'
+    mock.register_uri(
+        HttpMethod.GET,
+        url,
+        content=b'A' * 8,
+        headers={'Content-Length': '999999'},
+    )
+    capped_client = (
+        RequestsHttpClientBuilder().set_max_response_body_bytes(16).build()
+    )
+    with self.assertRaisesRegex(IOError, 'advertised 999999 bytes'):
+      capped_client.send(
+          HttpRequest().get(url).with_empty_headers().build()
+      )
+
+  @requests_mock.mock()
+  def test_send_when_response_body_within_cap_returns_expected_response(
+      self, mock
+  ):
+    url = 'http://example.com/get/within-cap'
+    body = b'tiny'
+    mock.register_uri(HttpMethod.GET, url, content=body)
+    capped_client = (
+        RequestsHttpClientBuilder().set_max_response_body_bytes(16).build()
+    )
+    response = capped_client.send(
+        HttpRequest().get(url).with_empty_headers().build()
+    )
+    self.assertEqual(response.body, body)
+
   def test_send_when_request_failed_raise_error(self):
     url = 'http://example.com/post/test-path'
     with self.assertRaises(requests.exceptions.RequestException):

--- a/plugin_server/py/plugin_server.py
+++ b/plugin_server/py/plugin_server.py
@@ -50,6 +50,13 @@ _OUTPUT = flags.DEFINE_string('log_output', '/tmp',
 _TIMEOUT_SEC = flags.DEFINE_float(
     'timeout_seconds', 10, 'Timeout in seconds for complete HTTP calls.'
 )
+_MAX_RESPONSE_BODY_MB = flags.DEFINE_integer(
+    'max_response_body_mb',
+    100,
+    'Maximum size in megabytes of an HTTP response body the client will buffer'
+    ' in memory. Responses larger than this cause the affected probe to fail'
+    ' with an IOError while the surrounding scan continues.',
+)
 _LOG_ID = flags.DEFINE_string('log_id', '',
                               'id to track logs for all outgoing HTTP calls.')
 _TRUST_ALL_SSL_CERT = flags.DEFINE_boolean(
@@ -143,6 +150,7 @@ def _configure_plugin_service(server):
       .set_timeout_sec(_TIMEOUT_SEC.value)
       .set_verify_ssl(not _TRUST_ALL_SSL_CERT.value)
       .set_log_id(_LOG_ID.value)
+      .set_max_response_body_bytes(_MAX_RESPONSE_BODY_MB.value * 1024 * 1024)
       .build()
   )
   callback_client = TcsClient(


### PR DESCRIPTION
## Summary

Tsunami's HTTP egress paths buffered response bodies into memory with no size cap on three independent code paths. Because Tsunami probes adversarial endpoints by definition, a compromised target can detect the `TsunamiSecurityScanner` User-Agent on inbound requests and serve an unbounded chunked response — each chunk arrives within the read-timeout window so the read timeout never fires, and the body buffer grows until the JVM heap or the Python plugin server process is exhausted (CWE-770 / CWE-400). The end result: a compromised asset can deterministically crash the scanner that is probing it, producing the exact false-negative `"scanned, no findings"` outcome an attacker wants from a detection tool.

This patch caps response-body reads on all three paths.

## Affected sites

1. `common/.../OkHttpHttpClient.java :: parseResponse` — backs every detector going through `send` / `sendAsync`. `okResponse.body().bytes()` only enforces a 2 GB ceiling on bodies whose `Content-Length` is advertised; chunked-encoded responses with no `Content-Length` bypass it entirely.
2. `common/.../OkHttpHttpClient.java :: sendAsIs` — used by the crafted-URL probes (path-traversal probes, percent-encoded edge cases) that are most likely to fire against hostile targets. `ByteString.readFrom` drains the raw `HttpURLConnection` stream until EOF with no ceiling at all.
3. `plugin_server/py/.../requests_http_client.py` — `session.send()` defaults to `stream=False`, which buffers the entire body inside the `Response` object before returning. `res.content` then returns those cached bytes unconditionally; a malicious chunked peer OOMs the Python plugin server before `_parse_response` is ever entered.

## Fix

Introduce a configurable `max_response_body_bytes` cap (default **100 MB**) enforced at every body-ingestion point.

* Reads are drained chunk-by-chunk into a bounded buffer.
* `Content-Length`, when advertised, is checked against the cap up front (cheap pre-flight rejection).
* Once the running total exceeds the cap, the underlying connection is closed and the call fails with `IOException` (Java) / `IOError` (Python).
* The affected probe errors out cleanly; the surrounding scan continues, including all subsequent detectors against the same and other targets.
* No detector code is touched, and no detector behavior changes for any response under the cap.

### Java wiring

* New `HttpClientModule.@MaxResponseBodyBytes` Guice qualifier + provider resolves CLI → config → default in the same null-coalescing pattern already used for the timeout fields:
  * CLI: `--http-client-max-response-body-mb` (in `HttpClientCliOptions`)
  * Config: `common.net.http.maxResponseBodyMb` (in `HttpClientConfigProperties`)
  * Default: 100 MB (`OkHttpHttpClient.DEFAULT_MAX_RESPONSE_BODY_BYTES`)
* New `OkHttpHttpClient` constructor + `OkHttpHttpClientBuilder.setMaxResponseBodyBytes` setter expose the cap. The legacy 6-arg constructor is preserved (it now delegates to the 7-arg form with the default), so external callers stay source-compatible.

### Python wiring

* New `--max_response_body_mb` absl flag in `plugin_server.py` plumbed through `RequestsHttpClientBuilder.set_max_response_body_bytes` into `RequestsHttpClient`.
* `session.send()` now passes `stream=True` on both the sync and async paths so the body never lands in the Response object before we have a chance to cap it.

## Tests

* `OkHttpHttpClientTest`:
  * `send_whenResponseBodyExceedsCap_throwsIOException`
  * `sendAsIs_whenResponseBodyExceedsCap_throwsIOException`
  * `send_whenResponseBodyWithinCap_returnsExpectedHttpResponse`
* `requests_http_client_test`:
  * `test_send_when_response_body_exceeds_cap_raises_io_error` (cap hit on streamed bytes)
  * `test_send_when_advertised_content_length_exceeds_cap_raises_io_error` (cap hit on advertised Content-Length pre-flight)
  * `test_send_when_response_body_within_cap_returns_expected_response` (golden-path regression)

## Compatibility

* Default cap of 100 MB is orders of magnitude larger than any legitimate HTML/JSON detector response. No existing detector should observe behavior changes.
* Java legacy 6-arg `OkHttpHttpClient` constructor preserved with default cap, so any out-of-tree caller (unlikely given the package-private constructor, but listed for completeness) continues to compile.
* Operators who legitimately need to ingest very large bodies (e.g. a multi-GB diagnostics endpoint) can raise the cap via `--http-client-max-response-body-mb` (Java) or `--max_response_body_mb` (Python) — or fall to a smaller value to harden further against malicious targets.

## Test plan

- [ ] CI runs `./gradlew test` against the patched Java sources (I was unable to run gradle locally — no wrapper checked into the repo and no system gradle on my dev box; relying on this PR's CI).
- [ ] CI runs the Python plugin-server pytest suite against the patched `requests_http_client_test.py` (`requests-mock` + `absl-py` not in my local env; relying on CI).
- [ ] Manual sanity test: run the scanner against a target that streams a chunked response with no `Content-Length` and verify the affected probe errors out with the cap message rather than crashing the JVM / Python process.

## References

- CWE-770: Allocation of Resources Without Limits or Throttling
- CWE-400: Uncontrolled Resource Consumption
- OkHttp `ResponseBody` documentation — note on body size and streaming