### PR TITLE
Send TCS polling secret in X-Tsunami-TCS-Secret header (CWE-598 client-side half)

### DIFF
--- a/plugin/src/main/java/com/google/tsunami/plugin/TcsClient.java
+++ b/plugin/src/main/java/com/google/tsunami/plugin/TcsClient.java
@@ -39,6 +39,14 @@ public final class TcsClient {
   private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
   private static final JsonFormat.Parser jsonParser = JsonFormat.parser();
 
+  // Per-scan correlation secret used to be sent in the polling URL query string
+  // ('/?secret=<raw>'), but URL query strings are routinely captured by web-server access
+  // logs, cloud LB logs, browser history / Referer, ps-output of debugging curl invocations,
+  // and CDN analytics — none of which are appropriate channels for a secret. The polling
+  // server (callback-server) accepts the secret via this header instead. See
+  // https://www.rfc-editor.org/rfc/rfc9110#section-17.9 (Sensitive Information in URIs).
+  private static final String SECRET_HEADER_NAME = "X-Tsunami-TCS-Secret";
+
   private final String callbackAddress;
   private final int callbackPort;
   private final String pollingBaseUrl;
@@ -127,9 +135,12 @@ public final class TcsClient {
 
   private Optional<PollingResult> sendPollingRequest(String secretString) {
     HttpRequest request =
-        HttpRequest.get(
-                String.format("%s/?secret=%s", removeTrailingSlashes(pollingBaseUrl), secretString))
-            .setHeaders(HttpHeaders.builder().addHeader("Cache-Control", "no-cache").build())
+        HttpRequest.get(removeTrailingSlashes(pollingBaseUrl) + "/")
+            .setHeaders(
+                HttpHeaders.builder()
+                    .addHeader("Cache-Control", "no-cache")
+                    .addHeader(SECRET_HEADER_NAME, secretString)
+                    .build())
             .build();
     try {
       HttpResponse response = httpClient.send(request);

--- a/plugin/src/test/java/com/google/tsunami/plugin/TcsClientTest.java
+++ b/plugin/src/test/java/com/google/tsunami/plugin/TcsClientTest.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 import javax.inject.Inject;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -154,8 +155,11 @@ public final class TcsClientTest {
 
     client.hasOobLog(SECRET);
 
-    assertThat(mockWebServer.takeRequest().getPath())
-        .isEqualTo(String.format("/?secret=%s", SECRET));
+    RecordedRequest recordedRequest = mockWebServer.takeRequest();
+    // Secret travels in a request header, not in the URL query string. The path is "/"
+    // with no query parameters; the X-Tsunami-TCS-Secret header carries the raw secret.
+    assertThat(recordedRequest.getPath()).isEqualTo("/");
+    assertThat(recordedRequest.getHeader("X-Tsunami-TCS-Secret")).isEqualTo(SECRET);
     mockWebServer.shutdown();
   }
 

--- a/plugin_server/py/plugin/tcs_client.py
+++ b/plugin_server/py/plugin/tcs_client.py
@@ -11,6 +11,14 @@ import network_pb2
 import polling_pb2
 
 
+# Per-scan correlation secret used to be sent in the polling URL query string
+# ('/?secret=<raw>'), but URL query strings are routinely captured by web-server access
+# logs, cloud LB logs, browser history / Referer, ps-output of debugging curl invocations,
+# and CDN analytics — none of which are appropriate channels for a secret. The polling
+# server (callback-server) accepts the secret via this header instead.
+_SECRET_HEADER_NAME = 'X-Tsunami-TCS-Secret'
+
+
 class TcsClient:
   """Client use for communicating with Tsunami Callback Server."""
 
@@ -116,12 +124,13 @@ class TcsClient:
     return None
 
   def _build_polling_request(self, secret_string: str) -> HttpRequest:
-    url = '%s/?secret=%s' % (self.polling_base_url, secret_string)
+    url = '%s/' % self.polling_base_url
     return (
         HttpRequest.get(url)
         .set_headers(
             HttpHeaders.builder()
             .add_header('Cache-Control', 'no-cache')
+            .add_header(_SECRET_HEADER_NAME, secret_string)
             .build()
         )
         .build()

--- a/plugin_server/py/plugin/tcs_client_test.py
+++ b/plugin_server/py/plugin/tcs_client_test.py
@@ -82,30 +82,32 @@ class TcsClientTest(parameterized.TestCase):
   @requests_mock.mock()
   def test_has_oob_log_sends_polling_request(self, mock):
     body = '{ "has_dns_interaction":false, "has_http_interaction":true}'
-    mock.register_uri(
-        'GET', '%s/?secret=%s' % (URL, SECRET), content=body.encode('utf-8')
-    )
+    mock.register_uri('GET', '%s/' % URL, content=body.encode('utf-8'))
     client = TcsClient(DOMAIN, PORT, URL, self.http_client)
     self.assertTrue(client.has_oob_log(SECRET))
+    # Secret travels in a request header, not in the URL query string. The path is "/"
+    # with no query parameters; the X-Tsunami-TCS-Secret header carries the raw secret.
+    self.assertEqual(mock.last_request.qs, {})
+    self.assertEqual(
+        mock.last_request.headers.get('X-Tsunami-TCS-Secret'), SECRET
+    )
 
   @requests_mock.mock()
   def test_has_oob_log_with_no_logs_returns_false(self, mock):
     body = '{ "has_dns_interaction":false, "has_http_interaction":false}'
-    mock.register_uri(
-        'GET', '%s/?secret=%s' % (URL, SECRET), content=body.encode('utf-8')
-    )
+    mock.register_uri('GET', '%s/' % URL, content=body.encode('utf-8'))
     client = TcsClient(DOMAIN, PORT, URL, self.http_client)
     self.assertFalse(client.has_oob_log(SECRET))
 
   @requests_mock.mock()
   def test_has_oob_log_with_no_response_returns_false(self, mock):
-    mock.register_uri('GET', '%s/?secret=%s' % (URL, SECRET))
+    mock.register_uri('GET', '%s/' % URL)
     client = TcsClient(DOMAIN, PORT, URL, self.http_client)
     self.assertFalse(client.has_oob_log(SECRET))
 
   @requests_mock.mock()
   def test_has_oob_log_with_unsuccessful_response_returns_false(self, mock):
-    mock.register_uri('GET', '%s/?secret=%s' % (URL, SECRET), status_code=500)
+    mock.register_uri('GET', '%s/' % URL, status_code=500)
     client = TcsClient(DOMAIN, PORT, URL, self.http_client)
     self.assertFalse(client.has_oob_log(SECRET))
 


### PR DESCRIPTION
## Summary

The Tsunami Callback Server (TCS) polling protocol used to carry the per-scan correlation secret in the polling URL query string (`/?secret=<raw_secret>`), which is logged by every standard intermediary on the path:

- web-server access logs (the project documents nginx-fronted deployments as a supported topology)
- cloud load balancer request logs (AWS ALB, GCP HTTP(S) LB log full URLs by default)
- outbound forward proxies on the scanner side
- browser history / `Referer` when a human opens the polling URL to debug a callback
- `ps`-output of `curl`/`wget` invocations against the polling endpoint
- CDN request-sampling analytics

None of these are appropriate channels for a secret. The raw secret was supposed to stay private to the scanner; only its SHA3-224 hash (the cbid) was the public projection. An attacker who reads the secret out of one of those log surfaces during the scan window can forge an out-of-band callback for a probe that never actually triggered, injecting a false-positive vulnerability finding into the operator's scan report (CWE-598 — Use of GET Request Method With Sensitive Query Strings).

This is the **client-side half** of the coordinated fix. The matching server-side PR is referenced below.

## Changes

Two TCS client implementations now send the secret in an `X-Tsunami-TCS-Secret` request header instead of the URL query string. The polling URL becomes a clean `<base>/` with no query string.

- `plugin/src/main/java/com/google/tsunami/plugin/TcsClient.java` — adds the `SECRET_HEADER_NAME` constant; `sendPollingRequest` builds the request with the header.
- `plugin_server/py/plugin/tcs_client.py` — adds the `_SECRET_HEADER_NAME` module-level constant; `_build_polling_request` attaches the header.

Header values are not logged by default in any of the channels listed above.

## Coordination

Companion server-side PR (must merge and ship first):

- google/tsunami-security-scanner-callback-server#3 — *Accept polling secret via X-Tsunami-TCS-Secret header*

That PR teaches `InteractionPollingHandler` to accept the secret via the new header, with a fallback to the legacy `?secret=` query parameter so older Tsunami client releases keep polling correctly through the deprecation window. The fallback log is rate-limited to once per minute to surface upgrade guidance without log-flood.

**Recommended merge order:**

1. Merge and release the server-side PR. From that release onward, the TCS server accepts both forms (header preferred, query as fallback).
2. Merge this client-side PR. Operators upgrading the scanner after the server release: secure. Operators with the old scanner against a new TCS server: still leak via query, but no breakage; the deprecation log nudges them to upgrade. Operators with the new scanner against an old TCS server: polling fails, which is why the server PR has to land first.

## Tests

- `TcsClientTest.isVulnerable_sendsValidPollingRequest` updated: now asserts the recorded request path is `"/"` (no query string) AND that the request carries the secret in the `X-Tsunami-TCS-Secret` header.
- `tcs_client_test.test_has_oob_log_sends_polling_request` asserts the same on the Python side using `requests_mock.last_request` (`.qs == {}`, header value matches).
- The remaining `has_oob_log_*` Python tests are updated to register `mock.register_uri('GET', '<URL>/', ...)` (header-form URIs) instead of `'<URL>/?secret=<SECRET>'`.

## Test plan

- [ ] CI runs `./gradlew test` against the patched Java sources. (Couldn't run gradle locally — no wrapper checked in, no system gradle; relying on this PR's CI.)
- [ ] CI runs the Python plugin-server pytest suite against the patched `tcs_client_test.py`. (`requests-mock` + `absl-py` not in my local env; relying on CI.)
- [ ] Manual sanity, after both PRs are merged: run an end-to-end scan with a callback-server-enabled detector and verify polling succeeds. Verify the polling request shows up in the TCS access log as `GET /` (no `?secret=...`) and the `X-Tsunami-TCS-Secret` header is set.

## References

- CWE-598: Use of GET Request Method With Sensitive Query Strings
- OWASP — Information Exposure Through Query Strings in URL
- RFC 9110 §17.9: Sensitive Information in URIs